### PR TITLE
Added exception check for last-sync-date

### DIFF
--- a/Tomboy-library/Tomboy/Sync/SyncManifest.cs
+++ b/Tomboy-library/Tomboy/Sync/SyncManifest.cs
@@ -155,12 +155,15 @@ namespace Tomboy.Sync
 					 select el.Attribute ("version").Value).Single ();
 				if (version != CURRENT_VERSION)
 					throw new TomboyException ("Syncmanifest is of unknown version");
-	
-				manifest.LastSyncDate =
-					(from  el in elements
-					where el.Name.LocalName == "last-sync-date"
-						select DateTime.Parse (el.Value)).Single ();
-	
+                try{
+                manifest.LastSyncDate =
+                	(from  el in elements
+                	where el.Name.LocalName == "last-sync-date"
+                		select DateTime.Parse (el.Value)).Single ();
+                }catch(InvalidOperationException e){
+                    manifest.LastSyncDate = DateTime.Now;
+                }
+
 				manifest.ServerId = 
 					(from el in elements where el.Name.LocalName == "server-id"
 					 select el.Value).Single();


### PR DESCRIPTION
I have added an exception block when getting the last-sync-date from manifest, this needs to be handled more elegantly for older versions of manifest.
